### PR TITLE
[chg] medpackage: fetch specific axes-lite branch

### DIFF
--- a/get_components.py
+++ b/get_components.py
@@ -23,7 +23,7 @@ ensure_dirs = [
 component_repos = [
     ('git', 'cpuvisor-srv', 'https://github.com/kencoken/cpuvisor-srv.git', 'al-integration-prep'),
     ('git', 'imsearch-tools', 'https://github.com/kencoken/imsearch-tools.git'),
-    ('git', 'medpackage', 'https://github.com/martin-xavier/medpackage.git'),
+    ('git', 'medpackage', '--branch axes-lite --single-branch https://github.com/martin-xavier/medpackage.git'),
     ('hg' , 'limas', 'https://bitbucket.org/alyr/limas'),
     ('git', 'axes-home', 'https://github.com/kevinmcguinness/axes-home.git'),
     ('git', 'axes-research', 'https://github.com/kevinmcguinness/axes-research.git'),


### PR DESCRIPTION
Hello,

This small change in 'get_components.py' fetches an axes-lite specific MED package.
The axes-lite MED package contains:
- axeslite_setup.sh   :  sets a softlink to config.json
- axeslite_collection_path.py  : parses config.json to obtain the collection's path
- axeslite_add_onthefly_event.sh  : when axeslite_setup.sh is run, this script works with the axes-lite collection directory defined in 'config.json'.

Xavier
